### PR TITLE
Aarch64 version list processing

### DIFF
--- a/gcc/common/config/aarch64/aarch64-common.cc
+++ b/gcc/common/config/aarch64/aarch64-common.cc
@@ -133,6 +133,43 @@ aarch64_handle_option (struct gcc_options *opts,
       opts->x_aarch64_flag_outline_atomics = val;
       return true;
 
+    case OPT_fafmv_:
+      if (arg) {
+          // List of features supported by AArch64
+          const char* aarch64_supported_versions[] = {
+              "sve", "sve2"
+          };
+          int num_versions = sizeof(aarch64_supported_versions) / sizeof(aarch64_supported_versions[0]);
+
+          char* features = xstrdup(arg);
+          char* feature = strtok(features, ",");
+          bool valid_features = true;
+
+          while (feature != NULL && valid_features) {
+              bool feature_found = false;
+              for (int i = 0; i < num_versions; i++) {
+                  if (strcmp(feature, aarch64_supported_versions[i]) == 0) {
+                      feature_found = true;
+                      break;
+                  }
+              }
+              if (!feature_found) {
+                  error_at(loc, "Unsupported feature '%s' in -fafmv for AArch64", feature);
+                  valid_features = false;
+              }
+              feature = strtok(NULL, ",");
+          }
+          free(features);
+          if (valid_features) {
+              printf("All specified AArch64 features are valid.\n");
+          } else {
+              return true;
+          }
+      } else {
+          error_at(loc, "Missing features for -fafmv option");
+      }
+    return true;
+
     default:
       return true;
     }


### PR DESCRIPTION
## Version list processing logic for ARM64

**Array Initialization:** An array of strings supported_versions lists all the compatible versions supported by the -fafmv option (currently).
**Memory Management**: xstrdup(arg) copies the input string to avoid changing the original directly, allowing safe use of strtok.
**Validation**: I use strtok to split the string into tokens separated by commas. Each token (feature) is checked against the supported_versions array. If a token doesn’t match any entry in the array, an error is thrown (using error_at, like everyone else) then valid_features is set to false.
**Final Checks and Cleanup**: After processing all features / tokens, the memory allocated for the string is freed. If all features are verified as valid, a confirmation message is printed. Otherwise, the case breaks.

## Use Case

now when the user is on an ARM64 processor using aarch64 type architecture and they use the command
```
gcc -march=armv8-a -fafmv=neon,sve main.cpp -o test_positive
```
they will get this message.

```
All specified Aarch64 features are valid.
```
Alternitavley when a version list is not compatible with the specified architecture you will get this error.
```
gcc -march=armv8-a -fafmv=sse2 main.cpp -o test_negative
```
as expected the error is thrown
```
error: Unsupported feature 'sse2' in -fafmv for AArch64
```
## Future Iterations

In the future for a more robust implementation I intend to add option handling for when the user is on other systems and for other architectures. as well use global variables list of supported versions available for processing, and abstract logic from this simple switch statement into another method to better follow GCC coding guidelines.