### PR TITLE
Diagnostic Output for AFMV

### DIFF
--- a/gcc/Makefile.in
+++ b/gcc/Makefile.in
@@ -1778,6 +1778,7 @@ OBJS = \
 	tree-tailcall.o \
 	tree-vect-generic.o \
 	gimple-isel.o \
+	test.o \
 	tree-vect-patterns.o \
 	tree-vect-data-refs.o \
 	tree-vect-stmts.o \
@@ -2846,6 +2847,7 @@ GTFILES = $(CPPLIB_H) $(srcdir)/input.h $(srcdir)/coretypes.h \
   $(srcdir)/btfout.cc \
   $(srcdir)/tree-vect-generic.cc \
   $(srcdir)/gimple-isel.cc \
+  $(srcdir)/test.cc \
   $(srcdir)/dojump.cc $(srcdir)/emit-rtl.h \
   $(srcdir)/emit-rtl.cc $(srcdir)/except.h $(srcdir)/explow.cc $(srcdir)/expr.cc \
   $(srcdir)/expr.h \

--- a/gcc/passes.def
+++ b/gcc/passes.def
@@ -446,7 +446,7 @@ along with GCC; see the file COPYING3.  If not see
   NEXT_PASS (pass_lower_resx);
   NEXT_PASS (pass_nrv);
   NEXT_PASS (pass_gimple_isel);
-  NEXT_PASS (pass_gimple_test);
+  NEXT_PASS (pass_test_dump);
   NEXT_PASS (pass_harden_conditional_branches);
   NEXT_PASS (pass_harden_compares);
   NEXT_PASS (pass_warn_access, /*early=*/false);

--- a/gcc/passes.def
+++ b/gcc/passes.def
@@ -446,6 +446,7 @@ along with GCC; see the file COPYING3.  If not see
   NEXT_PASS (pass_lower_resx);
   NEXT_PASS (pass_nrv);
   NEXT_PASS (pass_gimple_isel);
+  NEXT_PASS (pass_gimple_test);
   NEXT_PASS (pass_harden_conditional_branches);
   NEXT_PASS (pass_harden_compares);
   NEXT_PASS (pass_warn_access, /*early=*/false);

--- a/gcc/test.cc
+++ b/gcc/test.cc
@@ -31,12 +31,14 @@ namespace {
     public: pass_test_dump(gcc::context * ctxt): gimple_opt_pass(pass_data_gimple_test, ctxt) {}
 
     /* Pass gate function. */
-    bool gate(function*) final override {
+    bool
+    gate(function*) final override {
       return true;
     }
 
     /* Pass execution function. */
-    unsigned int execute(function*) final override {
+    unsigned int
+    execute(function*) final override {
       fprintf(stderr, "Hello World\n");
       return 0;
     }
@@ -44,6 +46,7 @@ namespace {
 }
 
 /* Create the test dump pass. */
-gimple_opt_pass * make_pass_test_dump(gcc::context * ctxt) {
+gimple_opt_pass
+*make_pass_test_dump(gcc::context * ctxt) {
   return new pass_test_dump(ctxt);
 }

--- a/gcc/test.cc
+++ b/gcc/test.cc
@@ -1,0 +1,49 @@
+#include "config.h"
+#include "system.h"
+#include "coretypes.h"
+#include "backend.h"
+#include "tree-pass.h"
+#include "gimple.h"
+
+namespace {
+  const pass_data pass_data_gimple_test = {
+    GIMPLE_PASS,
+    /* type */
+    "test",
+    /* name */
+    OPTGROUP_NONE,
+    /* optinfo_flags */
+    TV_NONE,
+    /* tv_id */
+    0,
+    /* properties_required */
+    0,
+    /* properties_provided */
+    0,
+    /* properties_destroyed */
+    0,
+    /* todo_flags_start */
+    0 /* todo_flags_finish */
+  };
+
+  /* Test pass for dumping a test message. */
+  class pass_test_dump: public gimple_opt_pass {
+    public: pass_test_dump(gcc::context * ctxt): gimple_opt_pass(pass_data_gimple_test, ctxt) {}
+
+    /* Pass gate function. */
+    bool gate(function*) final override {
+      return true;
+    }
+
+    /* Pass execution function. */
+    unsigned int execute(function*) final override {
+      fprintf(stderr, "Hello World\n");
+      return 0;
+    }
+  };
+}
+
+/* Create the test dump pass. */
+gimple_opt_pass * make_pass_test_dump(gcc::context * ctxt) {
+  return new pass_test_dump(ctxt);
+}

--- a/gcc/tree-pass.h
+++ b/gcc/tree-pass.h
@@ -658,6 +658,7 @@ extern gimple_opt_pass *make_pass_update_address_taken (gcc::context *ctxt);
 extern gimple_opt_pass *make_pass_convert_switch (gcc::context *ctxt);
 extern gimple_opt_pass *make_pass_lower_vaarg (gcc::context *ctxt);
 extern gimple_opt_pass *make_pass_gimple_isel (gcc::context *ctxt);
+extern gimple_opt_pass *make_pass_gimple_test (gcc::context *ctxt);
 extern gimple_opt_pass *make_pass_harden_compares (gcc::context *ctxt);
 extern gimple_opt_pass *make_pass_harden_conditional_branches (gcc::context
 							       *ctxt);

--- a/gcc/tree-pass.h
+++ b/gcc/tree-pass.h
@@ -658,7 +658,7 @@ extern gimple_opt_pass *make_pass_update_address_taken (gcc::context *ctxt);
 extern gimple_opt_pass *make_pass_convert_switch (gcc::context *ctxt);
 extern gimple_opt_pass *make_pass_lower_vaarg (gcc::context *ctxt);
 extern gimple_opt_pass *make_pass_gimple_isel (gcc::context *ctxt);
-extern gimple_opt_pass *make_pass_gimple_test (gcc::context *ctxt);
+extern gimple_opt_pass *make_pass_test_dump (gcc::context *ctxt);
 extern gimple_opt_pass *make_pass_harden_compares (gcc::context *ctxt);
 extern gimple_opt_pass *make_pass_harden_conditional_branches (gcc::context
 							       *ctxt);


### PR DESCRIPTION
This PR closes the this Issue.
#17 

It adds a test gimple pass which prints "Hello World" for now, but In the future I would like to integrate it with cloning and pruning and provide some diagnostic output to the developer .
