### PR TITLE
2024 s detect fmv afmv clash

### DIFF
--- a/gcc/common.opt
+++ b/gcc/common.opt
@@ -1040,6 +1040,10 @@ fabi-version=
 Common Joined RejectNegative UInteger Var(flag_abi_version) Init(0)
 The version of the C++ ABI in use.
 
+fafmv-test=
+Common Joined Var(str_afmv_test)
+My test option for afmv error generation.
+
 faggressive-loop-optimizations
 Common Var(flag_aggressive_loop_optimizations) Optimization Init(1)
 Aggressively optimize loops using language constraints.

--- a/gcc/multiple_target.cc
+++ b/gcc/multiple_target.cc
@@ -328,7 +328,8 @@ expand_target_clones (struct cgraph_node *node, bool definition)
   if (str_afmv_test)
   {
     error_at (DECL_SOURCE_LOCATION (node->decl), 
-    _("AFMV cannot be used together with FMV on function %q+F - either turn off AFMV, or remove %<target_clones%> attribute."), node->decl);
+    _("AFMV cannot be used together with FMV on function %q+F"), node->decl);
+    inform (DECL_SOURCE_LOCATION (node->decl), _("Either turn off AFMV, or remove %<target_clones%> attribute."));
     return false;
   }
 

--- a/gcc/multiple_target.cc
+++ b/gcc/multiple_target.cc
@@ -38,6 +38,7 @@ along with GCC; see the file COPYING3.  If not see
 #include "gimple-walk.h"
 #include "tree-inline.h"
 #include "intl.h"
+#include "options.h"
 
 /* Walker callback that replaces all FUNCTION_DECL of a function that's
    going to be versioned.  */
@@ -322,6 +323,14 @@ expand_target_clones (struct cgraph_node *node, bool definition)
 		  0, "single %<target_clones%> attribute is ignored");
       return false;
     }
+
+  /* Check for afmv collision, and error appropriately. */
+  if (str_afmv_test)
+  {
+    error_at (DECL_SOURCE_LOCATION (node->decl), 
+    _("AFMV cannot be used together with FMV on function %q+F ... either turn off AFMV, or remove %<target_clones%> attribute."), node->decl);
+    return false;
+  }
 
   if (node->definition
       && (node->alias || !tree_versionable_function_p (node->decl)))

--- a/gcc/multiple_target.cc
+++ b/gcc/multiple_target.cc
@@ -328,7 +328,7 @@ expand_target_clones (struct cgraph_node *node, bool definition)
   if (str_afmv_test)
   {
     error_at (DECL_SOURCE_LOCATION (node->decl), 
-    _("AFMV cannot be used together with FMV on function %q+F ... either turn off AFMV, or remove %<target_clones%> attribute."), node->decl);
+    _("AFMV cannot be used together with FMV on function %q+F - either turn off AFMV, or remove %<target_clones%> attribute."), node->decl);
     return false;
   }
 


### PR DESCRIPTION
## What was done?

Implemented AFMV-FMV collision error production.

**Note:** this implementation is using the '-fafmv-test' command-line option for testing, but should be changed to use the real option created in the '2024-S-command-line-parsing' branch, once combining all tasks together.

## Usage

After a build and fresh install of gcc, use it to compile a program that has the FMV target_clones attribute on at least one function, with the AFMV command-line option enabled to see the collision error identify the problem function and what to do about it.