### PR TITLE
Integrate command-line parsing with fmv-afmv collision detection

### DIFF
--- a/gcc/afmv.h
+++ b/gcc/afmv.h
@@ -1,0 +1,29 @@
+/* Copyright (C) 2003-2024 Free Software Foundation, Inc.
+
+This file is part of GCC.
+
+GCC is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free
+Software Foundation; either version 3, or (at your option) any later
+version.
+
+GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with GCC; see the file COPYING3.  If not see
+<http://www.gnu.org/licenses/>.  */
+
+#ifndef GCC_AFMV_H
+#define GCC_AFMV_H
+
+/* Storage global variable for AFMV*/
+
+#define AFMV_MAX_ARRAY_SIZE 100
+
+extern unsigned int afmv_cnt;
+extern char* afmv_targets[AFMV_MAX_ARRAY_SIZE];
+
+#endif /* GCC_AFMV_H */

--- a/gcc/common.opt
+++ b/gcc/common.opt
@@ -431,6 +431,10 @@ Driver Separate Undocumented MissingArgError(missing filename after %qs)
 -verbose
 Driver Alias(v)
 
+fafmv=
+Common Joined Var(flag_fafmv) Optimization
+Function automatic multiversioning
+
 ;; The driver used to convert options such as --help into forms such
 ;; as -fhelp; the following four entries are for compatibility with
 ;; any direct uses of those (undocumented) -f forms

--- a/gcc/multiple_target.cc
+++ b/gcc/multiple_target.cc
@@ -39,6 +39,7 @@ along with GCC; see the file COPYING3.  If not see
 #include "tree-inline.h"
 #include "intl.h"
 #include "options.h"
+#include "afmv.h"
 
 /* Walker callback that replaces all FUNCTION_DECL of a function that's
    going to be versioned.  */
@@ -325,7 +326,7 @@ expand_target_clones (struct cgraph_node *node, bool definition)
     }
 
   /* Check for afmv collision, and error appropriately. */
-  if (str_afmv_test)
+  if (afmv_cnt)
   {
     error_at (DECL_SOURCE_LOCATION (node->decl), 
     _("AFMV cannot be used together with FMV on function %q+F"), node->decl);

--- a/gcc/multiple_target.cc
+++ b/gcc/multiple_target.cc
@@ -39,7 +39,6 @@ along with GCC; see the file COPYING3.  If not see
 #include "tree-inline.h"
 #include "intl.h"
 #include "options.h"
-#include "afmv.h"
 
 /* Walker callback that replaces all FUNCTION_DECL of a function that's
    going to be versioned.  */
@@ -326,7 +325,7 @@ expand_target_clones (struct cgraph_node *node, bool definition)
     }
 
   /* Check for afmv collision, and error appropriately. */
-  if (afmv_cnt)
+  if (flag_fafmv)
   {
     error_at (DECL_SOURCE_LOCATION (node->decl), 
     _("AFMV cannot be used together with FMV on function %q+F"), node->decl);

--- a/gcc/opts.cc
+++ b/gcc/opts.cc
@@ -2746,6 +2746,40 @@ common_handle_option (struct gcc_options *opts,
     case OPT__completion_:
       break;
 
+    case OPT_fafmv_:
+      if (!arg) {
+        error_at(loc, "Missing options");
+      } else {
+        const char* supported_list[] = {
+          "simd", "neon", "sve", "sve2"
+        };
+        int list_len = sizeof(supported_list) / sizeof(supported_list[0]);
+        char* features = xstrdup(arg);
+        char* feature = strtok(features, ",");
+        bool is_valid = true;
+        while (feature != NULL && is_valid) {
+          bool is_found = false;
+          for (int i = 0; i < list_len; i++) {
+              if (strcmp(feature, supported_list[i]) == 0){
+                  is_found = true;
+                  break;
+              }
+          }
+          if (!is_found) {
+              error_at(loc, "Unsupported option '%s'", feature);
+              is_valid = false;
+          }
+          feature = strtok(NULL, ",");
+        }
+        free(features);
+        if (is_valid) {
+          printf("All option are valid.\n");
+        } else {
+          break;
+        }
+     }
+     break;
+
     case OPT_fsanitize_:
       opts_set->x_flag_sanitize = true;
       opts->x_flag_sanitize

--- a/gcc/opts.cc
+++ b/gcc/opts.cc
@@ -2779,6 +2779,7 @@ common_handle_option (struct gcc_options *opts,
         free(features);
         if (is_valid) {
           printf("All option are valid.\n");
+	  afmv_cnt--; // default count is set to 0
         } else {
           break;
         }

--- a/gcc/opts.cc
+++ b/gcc/opts.cc
@@ -35,6 +35,7 @@ along with GCC; see the file COPYING3.  If not see
 #include "version.h"
 #include "selftest.h"
 #include "file-prefix-map.h"
+#include "afmv.h"
 
 /* In this file all option sets are explicit.  */
 #undef OPTION_SET_P
@@ -2750,6 +2751,8 @@ common_handle_option (struct gcc_options *opts,
       if (!arg) {
         error_at(loc, "Missing options");
       } else {
+	unsigned int afmv_cnt = 0;
+        char* afmv_targets[AFMV_MAX_ARRAY_SIZE];
         const char* supported_list[] = {
           "simd", "neon", "sve", "sve2"
         };
@@ -2768,6 +2771,8 @@ common_handle_option (struct gcc_options *opts,
           if (!is_found) {
               error_at(loc, "Unsupported option '%s'", feature);
               is_valid = false;
+          } else {
+              afmv_targets[afmv_cnt++] = feature;
           }
           feature = strtok(NULL, ",");
         }

--- a/gcc/opts.cc
+++ b/gcc/opts.cc
@@ -2751,8 +2751,8 @@ common_handle_option (struct gcc_options *opts,
       if (!arg) {
         error_at(loc, "Missing options");
       } else {
-	unsigned int afmv_cnt = 0;
-        char* afmv_targets[AFMV_MAX_ARRAY_SIZE];
+	//unsigned int afmv_cnt = 0;
+        //char* afmv_targets[AFMV_MAX_ARRAY_SIZE];
         const char* supported_list[] = {
           "simd", "neon", "sve", "sve2"
         };
@@ -2771,15 +2771,15 @@ common_handle_option (struct gcc_options *opts,
           if (!is_found) {
               error_at(loc, "Unsupported option '%s'", feature);
               is_valid = false;
-          } else {
-              afmv_targets[afmv_cnt++] = feature;
+          //} else {
+              //afmv_targets[afmv_cnt++] = feature;
           }
           feature = strtok(NULL, ",");
         }
         free(features);
         if (is_valid) {
-          printf("All option are valid.\n");
-	  afmv_cnt--; // default count is set to 0
+          //printf("All option are valid.\n");
+	  //afmv_cnt--; // default count is set to 0
         } else {
           break;
         }


### PR DESCRIPTION
## What has been done?

- updated the collision detection and error production to integrate with the branch handling command-line parsing
- updated `gcc/opts.cc` to remove any references to `afmv_cnt` and `afmv_targets` variables, as those were causing issues when building
  - note: the variables are inaccessible across compilation units, and simply not using them would blow up the build with the warning about variables being set but unused - hence the removal
- updated `gcc/multiple-target.cc` to use command-line macro from "2024-S-command-line-parsing" branch
  - note: the name for this macro is misleading as it suggests the value is boolean when it actually would be a string (the name chosen by the command-line parsing branch developer is `flag_fafmv` which is poorly chosen and should be updated before making a submission to gcc)
  - the location of the command-line option within the larger context of the rest of the `common.opt` file is also oddly chosen, and should be moved to a more appropriate spot before making a submission to gcc
  - ideally, the variable `afmv_cnt` should be used to check for collision, but since that branch produces errors, we had to work around it by simply going off of the command-line macro instead


## Usage

- build/install this version of gcc, and use it to compile a program that uses FMV on at least one function (i.e., `__attribute__((target_clones("default","sve","sha2")))` )
- ensure that the afmv command-line option is set when compiling, ex. `-fafmv="sve"`
  - note: the command-line parsing branch currently only validates for simd, neon, sve, and sve2
- should notice the collision error being thrown with info regarding the problem and how to fix it
